### PR TITLE
deform/insert action nodes and subtrees for sarafunBT, stopTree preemption fix?

### DIFF
--- a/sarafun_tree/CMakeLists.txt
+++ b/sarafun_tree/CMakeLists.txt
@@ -94,3 +94,9 @@ target_link_libraries(PickupAction ${catkin_LIBRARIES})
 
 add_executable(RetractAction src/sarafun_action_nodes/RetractAction.cpp)
 target_link_libraries(RetractAction ${catkin_LIBRARIES})
+
+add_executable(InsertAction src/sarafun_action_nodes/InsertAction.cpp)
+target_link_libraries(InsertAction ${catkin_LIBRARIES})
+
+add_executable(DeformAction src/sarafun_action_nodes/DeformAction.cpp)
+target_link_libraries(DeformAction ${catkin_LIBRARIES})

--- a/sarafun_tree/include/sarafun_tree/ExecuteAction.h
+++ b/sarafun_tree/include/sarafun_tree/ExecuteAction.h
@@ -109,7 +109,7 @@ ExecuteAction<ActionClass, ActionGoal>::ExecuteAction(
     ROS_ERROR("%s could not connect to %s", bt_name.c_str(), actionlib_name.c_str());
     nh_.shutdown();
   } 
-  first_call_ = false;
+  first_call_ = true;
 }
 
 template <class ActionClass, class ActionGoal>
@@ -163,7 +163,7 @@ int ExecuteAction<ActionClass, ActionGoal>::executionRoutine() {
       return -1; // Failure
     }
     start_time_ = ros::Time::now();
-
+	std::cout <<"Action started:"<<start_time_.toSec()<<std::endl;
     bool has_parameters = fillGoal(goal_);
 
     if (!has_parameters) {

--- a/sarafun_tree/include/sarafun_tree/ExecuteAction.h
+++ b/sarafun_tree/include/sarafun_tree/ExecuteAction.h
@@ -153,6 +153,7 @@ void ExecuteAction<ActionClass, ActionGoal>::preemptionRoutine() {
 template <class ActionClass, class ActionGoal>
 int ExecuteAction<ActionClass, ActionGoal>::executionRoutine() {
   boost::lock_guard<boost::mutex> guard(action_mutex_);
+//   ROS_ERROR_STREAM("Action: "<< action_name_<<" first call: "<<first_call_);
   if (first_call_ && isSystemActive()) // fresh call!
   {
     ROS_INFO("Action %s is waiting for the corresponding actionlib server!", action_name_.c_str());
@@ -202,8 +203,12 @@ int ExecuteAction<ActionClass, ActionGoal>::executionRoutine() {
     ROS_INFO("Action finished: %s", state.toString().c_str());
 
     if (state == actionlib::SimpleClientGoalState::SUCCEEDED) {
+      first_call_ = true;
       return 1;
-    } else {
+    } else if (state == actionlib::SimpleClientGoalState::ABORTED) {
+      first_call_ = true;
+      return -1;
+    }else{
       return -1;
     }
   } else {
@@ -223,11 +228,12 @@ template <class ActionClass, class ActionGoal>
 void ExecuteAction<ActionClass, ActionGoal>::cancelActionGoal()
 {
   actionlib::SimpleClientGoalState goal_state = action_client_->getState();
-  if (goal_state != actionlib::SimpleClientGoalState::ACTIVE)
-  {
+//   if (goal_state == actionlib::SimpleClientGoalState::ACTIVE)
+//   {
+	  ROS_WARN("Calling cancelGoal");
     action_client_->cancelGoal(); // To be safe
     first_call_ = true;
-  }
+//   }
 }
 
 template <class ActionClass, class ActionGoal>

--- a/sarafun_tree/include/sarafun_tree/sarafun_action_nodes/DeformAction.h
+++ b/sarafun_tree/include/sarafun_tree/sarafun_action_nodes/DeformAction.h
@@ -1,0 +1,34 @@
+#ifndef __DEFORM_ACTION__
+#define __DEFORM_ACTION__
+
+#include <ros/ros.h>
+#include <sarafun_tree/ExecuteAction.h>
+#include <sarafun_msgs/DeformationKeyframeAction.h>
+
+namespace sarafun {
+class DeformAction
+    : ExecuteAction<sarafun_msgs::DeformationKeyframeAction,
+                    sarafun_msgs::DeformationKeyframeGoal> {
+public:
+  DeformAction(std::string node_name, std::string action_name,
+                        std::string bt_name)
+      : ExecuteAction<
+            sarafun_msgs::DeformationKeyframeAction,
+            sarafun_msgs::DeformationKeyframeGoal>::ExecuteAction(node_name,
+                                                               action_name,
+                                                               bt_name),
+        node_name_(node_name), bt_name_(bt_name) {
+    node_handle_ = ros::NodeHandle(node_name);
+  }
+  ~DeformAction() {}
+
+  bool fillGoal(sarafun_msgs::DeformationKeyframeGoal &goal);
+  double getTimeoutValue();
+
+private:
+  ros::NodeHandle node_handle_;
+  std::string node_name_;
+  std::string bt_name_;
+};
+}
+#endif

--- a/sarafun_tree/include/sarafun_tree/sarafun_action_nodes/InsertAction.h
+++ b/sarafun_tree/include/sarafun_tree/sarafun_action_nodes/InsertAction.h
@@ -1,0 +1,34 @@
+#ifndef __INSERT_ACTION__
+#define __INSERT_ACTION__
+
+#include <ros/ros.h>
+#include <sarafun_tree/ExecuteAction.h>
+#include <sarafun_msgs/InsertionKeyframeAction.h>
+
+namespace sarafun {
+class InsertAction
+    : ExecuteAction<sarafun_msgs::InsertionKeyframeAction,
+                    sarafun_msgs::InsertionKeyframeGoal> {
+public:
+  InsertAction(std::string node_name, std::string action_name,
+                        std::string bt_name)
+      : ExecuteAction<
+            sarafun_msgs::InsertionKeyframeAction,
+            sarafun_msgs::InsertionKeyframeGoal>::ExecuteAction(node_name,
+                                                               action_name,
+                                                               bt_name),
+        node_name_(node_name), bt_name_(bt_name) {
+    node_handle_ = ros::NodeHandle(node_name);
+  }
+  ~InsertAction() {}
+
+  bool fillGoal(sarafun_msgs::InsertionKeyframeGoal &goal);
+  double getTimeoutValue();
+
+private:
+  ros::NodeHandle node_handle_;
+  std::string node_name_;
+  std::string bt_name_;
+};
+}
+#endif

--- a/sarafun_tree/src/sarafun_action_nodes/DeformAction.cpp
+++ b/sarafun_tree/src/sarafun_action_nodes/DeformAction.cpp
@@ -1,0 +1,41 @@
+#include <sarafun_tree/sarafun_action_nodes/DeformAction.h>
+
+namespace sarafun {
+bool DeformAction::fillGoal(sarafun_msgs::DeformationKeyframeGoal &goal) {
+  int idx;
+
+  fillParameter("/sarafun/deform/idx", 0, idx);
+  goal.idx = idx;
+
+  return true;
+}
+
+double DeformAction::getTimeoutValue() {
+  double timeout = 0;
+  fillParameter("/sarafun/bt_action_nodes/deform/timeout", 30.0, timeout);
+
+  return timeout;
+}
+}
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "DeformAction");
+  std::string bt_client_name, action_server_name;
+
+  if (!ros::param::get("/sarafun/bt_action_nodes/deform/action_server_name", action_server_name))
+  {
+    ROS_ERROR("%s missing action server name", ros::this_node::getName().c_str());
+    return -1;
+  }
+
+  if (!ros::param::get("/sarafun/bt_action_nodes/deform/bt_client_name", bt_client_name))
+  {
+    ROS_ERROR("%s missing bt client name", ros::this_node::getName().c_str());
+    return -1;
+  }
+
+  sarafun::DeformAction deform_action(
+      ros::this_node::getName(),  action_server_name, bt_client_name);
+  ros::spin();
+  return 1;
+}

--- a/sarafun_tree/src/sarafun_action_nodes/GraspAction.cpp
+++ b/sarafun_tree/src/sarafun_action_nodes/GraspAction.cpp
@@ -7,7 +7,9 @@ bool GraspAction::fillGoal(sarafun_msgs::GraspKeyframeGoal &goal) {
 
 double GraspAction::getTimeoutValue() {
   double timeout = 0;
-  fillParameter("/sarafun/bt_action_nodes/grasp/timeout", 30.0, timeout);
+  std::string ns = ros::this_node::getNamespace();
+  ns=ns+"/";
+  fillParameter("/sarafun/bt_action_nodes/"+ns+"grasp/timeout", 30.0, timeout);
 
   return timeout;
 }
@@ -16,14 +18,15 @@ double GraspAction::getTimeoutValue() {
 int main(int argc, char **argv) {
   ros::init(argc, argv, "GraspAction");
   std::string bt_client_name, action_server_name;
-
-  if (!ros::param::get("/sarafun/bt_action_nodes/grasp/action_server_name", action_server_name))
+  std::string ns = ros::this_node::getNamespace();
+  ns=ns+"/";
+  if (!ros::param::get("/sarafun/bt_action_nodes/"+ns+"grasp/action_server_name", action_server_name))
   {
     ROS_ERROR("%s missing action server name", ros::this_node::getName().c_str());
     return -1;
   }
 
-  if (!ros::param::get("/sarafun/bt_action_nodes/grasp/bt_client_name", bt_client_name))
+  if (!ros::param::get("/sarafun/bt_action_nodes/"+ns+"grasp/bt_client_name", bt_client_name))
   {
     ROS_ERROR("%s missing bt client name", ros::this_node::getName().c_str());
     return -1;

--- a/sarafun_tree/src/sarafun_action_nodes/InsertAction.cpp
+++ b/sarafun_tree/src/sarafun_action_nodes/InsertAction.cpp
@@ -1,0 +1,41 @@
+#include <sarafun_tree/sarafun_action_nodes/InsertAction.h>
+
+namespace sarafun {
+bool InsertAction::fillGoal(sarafun_msgs::InsertionKeyframeGoal &goal) {
+  int idx;
+
+  fillParameter("/sarafun/insert/idx", 0, idx);
+  goal.idx = idx;
+
+  return true;
+}
+
+double InsertAction::getTimeoutValue() {
+  double timeout = 0;
+  fillParameter("/sarafun/bt_action_nodes/insert/timeout", 30.0, timeout);
+
+  return timeout;
+}
+}
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "InsertAction");
+  std::string bt_client_name, action_server_name;
+
+  if (!ros::param::get("/sarafun/bt_action_nodes/insert/action_server_name", action_server_name))
+  {
+    ROS_ERROR("%s missing action server name", ros::this_node::getName().c_str());
+    return -1;
+  }
+
+  if (!ros::param::get("/sarafun/bt_action_nodes/insert/bt_client_name", bt_client_name))
+  {
+    ROS_ERROR("%s missing bt client name", ros::this_node::getName().c_str());
+    return -1;
+  }
+
+  sarafun::InsertAction insert_action(
+      ros::this_node::getName(),  action_server_name, bt_client_name);
+  ros::spin();
+  return 1;
+}

--- a/tree_generator/data/subtrees/deform.json
+++ b/tree_generator/data/subtrees/deform.json
@@ -1,0 +1,10 @@
+{
+  "root": "deform",
+  "nodes":{
+    "deform": {
+        "id": "deform",
+        "type": "Action",
+        "name": "deform_action"
+    }
+  }
+}

--- a/tree_generator/data/subtrees/grasp_parallel.json
+++ b/tree_generator/data/subtrees/grasp_parallel.json
@@ -1,0 +1,59 @@
+{
+  "root": "parallel",
+  "nodes": {
+    "parallel": {
+      "id": "parallel",
+      "type": "Parallel",
+      "name": "Parallel",
+      "SuccessNum": "2",
+      "children": [
+        "grasp_surface_sequence",
+        "grasp_rod_sequence"
+      ]
+    },
+    "grasp_surface_sequence": {
+      "id": "sequence",
+      "type": "SequenceStar",
+      "name": "SequenceStar",
+      "children": [
+        "grasp_surface_loader",
+        "grasp_surface"
+      ]
+    },
+    "grasp_surface_loader": {
+      "id": "loader",
+      "type": "Loader",
+      "name": "Loader",
+      "parameters": {
+        "/grasp_action_1/object_id": "surface_part"
+      }
+    },
+    "grasp_surface": {
+        "id": "grasp",
+        "type": "Action",
+        "name": "grasp_action_1"
+    },
+    "grasp_rod_sequence": {
+      "id": "sequence",
+      "type": "SequenceStar",
+      "name": "SequenceStar",
+      "children": [
+        "grasp_rod_loader",
+        "grasp_rod"
+      ]
+    },
+    "grasp_rod_loader": {
+      "id": "loader",
+      "type": "Loader",
+      "name": "Loader",
+      "parameters": {
+        "/grasp_action_2/object_id": "rod_part"
+      }
+    },
+    "grasp_rod": {
+        "id": "grasp",
+        "type": "Action",
+        "name": "grasp_action_2"
+    }
+  }
+}

--- a/tree_generator/data/subtrees/insert.json
+++ b/tree_generator/data/subtrees/insert.json
@@ -1,0 +1,10 @@
+{
+  "root": "insert",
+  "nodes":{
+    "insert": {
+        "id": "insert",
+        "type": "Action",
+        "name": "retract_action"
+    }
+  }
+}

--- a/tree_generator/data/subtrees/subtrees.yaml
+++ b/tree_generator/data/subtrees/subtrees.yaml
@@ -3,7 +3,7 @@ initial:
   file: initial.json
 
 grasp:
-  file: grasp.json
+  file: grasp_parallel.json
 
 pick_up:
   file: pick.json
@@ -26,3 +26,8 @@ contact:
 move:
   file: move.json
 
+insert:
+  file: insert.json
+  
+deform:
+  file: deform.json  


### PR DESCRIPTION
I added the subtrees and action nodes for deform and insert keyframes. I tried the /sarafun/stop_tree service and it did not request action preemption although the prompt stated otherwise. I think that I fixed it. I am not sure though.